### PR TITLE
Allow the use of cargo-deps as a library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ version = "1.1.1"
 
 edition = "2018"
 
+[[bin]]
+name = "cargo-deps"
+path = "src/main.rs"
+
 [dependencies]
 clap = "2"
 toml = "0.5"

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use crate::error::CliResult;
 use clap::ArgMatches;
 use std::str::FromStr;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Config {
     pub depth: Option<usize>,
     pub dot_file: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,10 @@ use std::{
     io::{self, BufWriter},
     path::Path,
 };
-use {
-    config::Config,
-    error::{CliError, CliResult},
-    project::Project,
-};
+
+use config::Config;
+use error::{CliError, CliResult};
+use project::Project;
 
 pub fn execute(cfg: Config) -> CliResult<()> {
     // Search through parent dirs for Cargo.toml.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,67 @@
+mod dep;
+mod error;
+mod graph;
+mod project;
+mod util;
+
+pub mod config;
+
+use {
+    config::Config,
+    error::{CliError, CliResult},
+    project::Project,
+};
+use std::{
+    fs::File,
+    io::{self, BufWriter},
+    path::Path
+};
+
+pub fn execute(cfg: Config) -> CliResult<()> {
+    // Search through parent dirs for Cargo.toml.
+    is_cargo_toml(&cfg.manifest_path)?;
+    let manifest_path = util::find_manifest_file(&cfg.manifest_path)?;
+
+    // Cargo.lock must be in the same directory as Cargo.toml or in a parent directory.
+    let manifest = manifest_path.to_str().unwrap();
+    let lock_file = format!("{}.lock", &manifest[0..manifest.len() - 5]);
+    let lock_path = util::find_manifest_file(&lock_file)?;
+
+    // Graph the project.
+    let dot_file = cfg.dot_file.clone();
+    let project = Project::with_config(cfg)?;
+    let graph = project.graph(manifest_path, lock_path)?;
+
+    // Render the dot file.
+    match dot_file {
+        None => {
+            let o = io::stdout();
+            let mut bw = BufWriter::new(o.lock());
+            graph.render_to(&mut bw)
+        }
+        Some(file) => {
+            let o = File::create(&Path::new(&file)).expect("Failed to create file");
+            let mut bw = BufWriter::new(o);
+            graph.render_to(&mut bw)
+        }
+    }
+}
+
+// Check that the manifest file name is "Cargo.toml".
+fn is_cargo_toml(file_name: &str) -> CliResult<()> {
+    let path = Path::new(file_name);
+
+    if let Some(file_name) = path.file_name() {
+        if file_name != "Cargo.toml" {
+            return Err(CliError::Toml(
+                "The manifest-path must be a path to a Cargo.toml file".into(),
+            ));
+        }
+    } else {
+        return Err(CliError::Toml(
+            "The manifest path is not a valid file".into(),
+        ));
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 mod config;
 mod dep;
 mod error;
@@ -29,12 +31,12 @@ pub fn get_dep_graph(cfg: Config) -> CliResult<DepGraph> {
 }
 
 pub fn render_dep_graph(graph: DepGraph) -> CliResult<String> {
-    let mut v: Vec<u8> = Vec::new();
-    let mut bw = BufWriter::new(&mut v);
-    graph.render_to(&mut bw)?;
-    drop(bw);
+    let mut bytes: Vec<u8> = Vec::new();
+    let mut writer = BufWriter::new(&mut bytes);
+    graph.render_to(&mut writer)?;
+    drop(writer);
 
-    String::from_utf8(v).map_err(|err| CliError::Generic(err.to_string()))
+    String::from_utf8(bytes).map_err(|err| CliError::Generic(err.to_string()))
 }
 
 // Check that the manifest file name is "Cargo.toml".

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,20 @@
 mod dep;
-mod error;
 mod graph;
 mod project;
 mod util;
 
 pub mod config;
+pub mod error;
 
+use std::{
+    fs::File,
+    io::{self, BufWriter},
+    path::Path,
+};
 use {
     config::Config,
     error::{CliError, CliResult},
     project::Project,
-};
-use std::{
-    fs::File,
-    io::{self, BufWriter},
-    path::Path
 };
 
 pub fn execute(cfg: Config) -> CliResult<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,24 +68,24 @@ fn parse_cli<'a>() -> ArgMatches<'a> {
 }
 
 fn main() {
-    let m = parse_cli();
+    let args = parse_cli();
 
-    if let Some(m) = m.subcommand_matches("deps") {
-        let cfg = Config::from_matches(&m).unwrap_or_else(|e| e.exit());
+    if let Some(arg) = args.subcommand_matches("deps") {
+        let cfg = Config::from_matches(&arg).unwrap_or_else(|e| e.exit());
         let dot_file = cfg.dot_file.clone();
 
         // Get dependency graph & render it
-        let o = get_dep_graph(cfg)
-            .and_then(|g| render_dep_graph(g))
+        let out = get_dep_graph(cfg)
+            .and_then(render_dep_graph)
             .map_err(|e| e.exit())
             .unwrap();
 
-        // Output to stoud or render the dot file
+        // Output to stdout or render the dot file
         match dot_file {
             None => Box::new(io::stdout()) as Box<dyn Write>,
             Some(file) => Box::new(File::create(&Path::new(&file)).expect("Failed to create file")),
         }
-        .write_all(&o.into_bytes())
+        .write_all(&out.into_bytes())
         .expect("Unable to write graph");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,10 @@
 #[macro_use]
 extern crate clap;
 
-use cargo_deps::config::Config;
-use cargo_deps::execute;
-use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use std::str::FromStr;
+
+use cargo_deps::{config::Config, execute};
+use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 
 const USAGE: &str = "\
 cargo-deps writes a graph in dot format to standard output.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,27 +2,11 @@
 
 #[macro_use]
 extern crate clap;
-extern crate toml;
 
-mod config;
-mod dep;
-mod error;
-mod graph;
-mod project;
-mod util;
-
-use crate::{
-    config::Config,
-    error::{CliError, CliResult},
-    project::Project,
-};
+use cargo_deps::config::Config;
+use cargo_deps::execute;
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
-use std::{
-    fs::File,
-    io::{self, BufWriter},
-    path::Path,
-    str::FromStr,
-};
+use std::str::FromStr;
 
 const USAGE: &str = "\
 cargo-deps writes a graph in dot format to standard output.
@@ -85,53 +69,4 @@ fn main() {
         let cfg = Config::from_matches(&m).unwrap_or_else(|e| e.exit());
         execute(cfg).map_err(|e| e.exit()).unwrap();
     }
-}
-
-fn execute(cfg: Config) -> CliResult<()> {
-    // Search through parent dirs for Cargo.toml.
-    is_cargo_toml(&cfg.manifest_path)?;
-    let manifest_path = util::find_manifest_file(&cfg.manifest_path)?;
-
-    // Cargo.lock must be in the same directory as Cargo.toml or in a parent directory.
-    let manifest = manifest_path.to_str().unwrap();
-    let lock_file = format!("{}.lock", &manifest[0..manifest.len() - 5]);
-    let lock_path = util::find_manifest_file(&lock_file)?;
-
-    // Graph the project.
-    let dot_file = cfg.dot_file.clone();
-    let project = Project::with_config(cfg)?;
-    let graph = project.graph(manifest_path, lock_path)?;
-
-    // Render the dot file.
-    match dot_file {
-        None => {
-            let o = io::stdout();
-            let mut bw = BufWriter::new(o.lock());
-            graph.render_to(&mut bw)
-        }
-        Some(file) => {
-            let o = File::create(&Path::new(&file)).expect("Failed to create file");
-            let mut bw = BufWriter::new(o);
-            graph.render_to(&mut bw)
-        }
-    }
-}
-
-// Check that the manifest file name is "Cargo.toml".
-fn is_cargo_toml(file_name: &str) -> CliResult<()> {
-    let path = Path::new(file_name);
-
-    if let Some(file_name) = path.file_name() {
-        if file_name != "Cargo.toml" {
-            return Err(CliError::Toml(
-                "The manifest-path must be a path to a Cargo.toml file".into(),
-            ));
-        }
-    } else {
-        return Err(CliError::Toml(
-            "The manifest path is not a valid file".into(),
-        ));
-    }
-
-    Ok(())
 }

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -7,7 +7,7 @@ use cargo_deps::{get_dep_graph, render_dep_graph, Config};
 #[test]
 fn get_dep_graph_self() {
     let mut cfg = Config::default();
-    cfg.manifest_path = "../Cargo.toml".to_string();
+    cfg.manifest_path = "Cargo.toml".into();
     let graph = get_dep_graph(cfg).unwrap();
     assert!(graph.nodes.iter().any(|d| d.name == "clap"));
     assert!(graph.nodes.iter().any(|d| d.name == "toml"));
@@ -16,8 +16,11 @@ fn get_dep_graph_self() {
 #[test]
 fn render_dep_graph_self() {
     let mut cfg = Config::default();
-    cfg.manifest_path = "../Cargo.toml".to_string();
+    cfg.manifest_path = "Cargo.toml".into();
     let graph = get_dep_graph(cfg).unwrap();
     let out = render_dep_graph(graph).unwrap();
-    assert!(out.starts_with("digraph dependencies"));
+    assert_eq!(
+        out,
+        "digraph dependencies {\n\tn6 [label=\"cargo-deps\", shape=box];\n\n}\n"
+    );
 }

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -2,7 +2,7 @@ extern crate cargo_deps;
 
 use cargo_deps::{get_dep_graph, render_dep_graph, Config};
 
-//Note: these are really just smoke tests to ensure we can use cargo-deps as a lib
+// Note: these are really just smoke tests to ensure we can use cargo-deps as a lib
 
 #[test]
 fn get_dep_graph_self() {

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -1,0 +1,23 @@
+extern crate cargo_deps;
+
+use cargo_deps::{get_dep_graph, render_dep_graph, Config};
+
+//Note: these are really just smoke tests to ensure we can use cargo-deps as a lib
+
+#[test]
+fn get_dep_graph_self() {
+    let mut cfg = Config::default();
+    cfg.manifest_path = "../Cargo.toml".to_string();
+    let graph = get_dep_graph(cfg).unwrap();
+    assert!(graph.nodes.iter().any(|d| d.name == "clap"));
+    assert!(graph.nodes.iter().any(|d| d.name == "toml"));
+}
+
+#[test]
+fn render_dep_graph_self() {
+    let mut cfg = Config::default();
+    cfg.manifest_path = "../Cargo.toml".to_string();
+    let graph = get_dep_graph(cfg).unwrap();
+    let out = render_dep_graph(graph).unwrap();
+    assert!(out.starts_with("digraph dependencies"));
+}


### PR DESCRIPTION
Allows to use cargo-deps as a library from another crate.