### PR TITLE
Add optional dependency exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ For example, if a dependency is both a build and a dev dependency, then it will 
 
 Some Rust projects have really big dependency trees and maybe you just want to display certain dependencies, like the ones in the same workspace. Fortunately, `cargo-deps` provides the `--filter` option for this use case. Unfortunately, you have to explicitly list all the dependencies you want to keep, and `cargo-deps` doesn't detect workspaces just yet.
 
+### Excluding
+
+It can be useful to exclude certain crates from the graphs, this can be achieved with the `--exclude` flag taking the undesired crate(s) as argument.
+
 #### Depth
 
 In order to constrain the size of graphs and make them cleaner, it is possible to limit the output to dependencies within a certain depth using the `--depth` option.

--- a/src/args.rs
+++ b/src/args.rs
@@ -30,6 +30,10 @@ pub struct Args {
     /// Only display provided deps
     pub filter: Option<Vec<String>>,
 
+    #[structopt(long = "exclude", value_name = "DEPNAMES")]
+    /// Exclude provided deps
+    pub exclude: Option<Vec<String>>,
+
     #[structopt(
         long = "manifest-path",
         value_name = "PATH",
@@ -88,6 +92,7 @@ pub fn parse_args(args: Args) -> Config {
         depth: args.depth,
         dot_file: args.dot_file,
         filter: args.filter,
+        exclude: args.exclude,
         include_orphans: args.include_orphans,
         include_versions: args.include_versions,
         manifest_path: args.manifest_path,

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ pub struct Config {
     pub depth: Option<usize>,
     pub dot_file: Option<String>,
     pub filter: Option<Vec<String>>,
+    pub exclude: Option<Vec<String>>,
     pub include_orphans: bool,
     pub include_versions: bool,
     /// Default: "Cargo.toml".
@@ -35,6 +36,7 @@ impl Default for Config {
             depth: None,
             dot_file: None,
             filter: None,
+            exclude: None,
             include_orphans: false,
             include_versions: false,
             manifest_path: "Cargo.toml".into(),

--- a/src/project.rs
+++ b/src/project.rs
@@ -216,6 +216,12 @@ fn parse_package(
             return Ok(());
         }
     }
+    let exclude = dg.cfg.exclude.clone();
+    if let Some(ref exclude_deps) = exclude {
+        if exclude_deps.contains(&name) {
+            return Ok(());
+        }
+    }
 
     let id = dg.find_or_add(&name, &ver);
 
@@ -254,6 +260,12 @@ fn parse_package(
 
             if let Some(ref filter_deps) = filter {
                 if !filter_deps.contains(&dep_name) {
+                    continue;
+                }
+            }
+
+            if let Some(ref exclude_deps) = exclude {
+                if exclude_deps.contains(&dep_name) {
                     continue;
                 }
             }

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -31,3 +31,17 @@ fn render_dep_graph_self() {
          }\n"
     );
 }
+
+#[test]
+fn render_dep_graph_self_exclusion() {
+    let mut cfg = Config::default();
+    cfg.depth = Some(1);
+    cfg.exclude = Some(vec!["structopt".to_string()]);
+    let graph = get_dep_graph(cfg).unwrap();
+    let out = render_dep_graph(graph).unwrap();
+    assert_eq!(
+        out,
+        // #[rustfmt::skip]
+        "digraph dependencies {\n\tn6 [label=\"cargo-deps\", shape=box];\n\tn7 [label=\"toml\"];\n\n\tn6 -> n7;\n}\n"
+    );
+}


### PR DESCRIPTION
Addresses #15 

Could use some review regarding how exclusion of the root should be handled, currently an error like this is emitted:
```
error: Could not parse toml file: Missing 'name': <crate_name> and 'version': 0.6.1 in lock file
```
where <crate_name> is the current root.